### PR TITLE
Queue refactor

### DIFF
--- a/src-tauri/src/endpoints/fs.rs
+++ b/src-tauri/src/endpoints/fs.rs
@@ -157,12 +157,6 @@ fn fsx_get_images(path: &Path, path_hash: &str) -> Result<Vec<EntityImage>, Stri
         let msg_path = path.to_string_lossy();
         send::info_window_msg(&format!("Generating {queue_count} thumbnails for: {msg_path}"));
     }
-    if queue_count == 0 {
-        // TODO: readability TODO_QUEUE_STATUS_PARAMS
-        // update to use enum/type params.
-        // sending: redraw=true, queue_empty=false
-        send::queue_status(path, &true, &false);
-    }
 
     images.sort_by(|a, b| a.filename.cmp(&b.filename));
 

--- a/src-tauri/src/endpoints/fs.rs
+++ b/src-tauri/src/endpoints/fs.rs
@@ -125,11 +125,11 @@ fn fsx_get_images(path: &Path, path_hash: &str) -> Result<Vec<EntityImage>, Stri
             if cache.is_none() {
                 queue_count += 1;
 
-                let queue_item = img_cache::queue::QueueItem {
-                    full_path: full_path.to_path_buf(),
-                    path_hash: path_hash.to_string().clone(),
-                    file_hash: file_hash.clone(),
-                };
+                let queue_item = img_cache::queue::QueueItem::new(
+                    full_path.to_path_buf(),
+                    path_hash.to_string(),
+                    file_hash.clone(),
+                );
                 tauri::async_runtime::spawn(async move {
                     if let Err(e) = get_queue().enqueue(queue_item).await {
                         error!("Failed to enqueue thumbnail job: {e}");

--- a/src-tauri/src/img_cache/img.rs
+++ b/src-tauri/src/img_cache/img.rs
@@ -4,7 +4,7 @@ use std::{fs::File, path::Path};
 pub fn create_thumbnail(org_path: &Path, thumb_path: &Path) -> Result<(), image::ImageError> {
     let img = ImageReader::open(org_path)?.decode()?;
 
-    let thumb = img.resize(400, 400, image::imageops::FilterType::Triangle);
+    let thumb = img.resize(400, 400, image::imageops::FilterType::Nearest);
     let output_file = File::create(thumb_path)?;
     let encoder = WebPEncoder::new_lossless(output_file);
 

--- a/src-tauri/src/img_cache/img.rs
+++ b/src-tauri/src/img_cache/img.rs
@@ -4,7 +4,7 @@ use std::{fs::File, path::Path};
 pub fn create_thumbnail(org_path: &Path, thumb_path: &Path) -> Result<(), image::ImageError> {
     let img = ImageReader::open(org_path)?.decode()?;
 
-    let thumb = img.resize(400, 400, image::imageops::FilterType::Nearest);
+    let thumb = img.resize(400, 400, image::imageops::FilterType::Triangle);
     let output_file = File::create(thumb_path)?;
     let encoder = WebPEncoder::new_lossless(output_file);
 

--- a/src-tauri/src/img_cache/mod.rs
+++ b/src-tauri/src/img_cache/mod.rs
@@ -2,3 +2,4 @@ pub mod cache;
 pub mod hash;
 pub mod img;
 pub mod queue;
+mod queue_worker;

--- a/src-tauri/src/img_cache/queue.rs
+++ b/src-tauri/src/img_cache/queue.rs
@@ -275,7 +275,3 @@ fn frontend_queue_progress(queue_size: usize) {
         send::info_window_msg(&format!("{queue_size:?} thumbnails in queue."));
     }
 }
-
-fn frontend_can_fetch(id: String){
-    // TODO: sends a message that the frontend can now fetch this image.
-}

--- a/src-tauri/src/img_cache/queue.rs
+++ b/src-tauri/src/img_cache/queue.rs
@@ -244,14 +244,18 @@ pub async fn setup_queue() -> Queue {
                     if !blacklist.insert(queue_id) {
                         error!("Failed to add to blacklist: {}", &file_hash);
                     }
+
+                    send::queue_status(&IpcQueueOpCode::ImageFailed, Some(&file_hash), None);
                 }
 
                 QueueMsg::WorkerErrorJoin { path, queue_id } => {
                     error!("Worker join error: {path}: {queue_id}");
+                    send::queue_status(&IpcQueueOpCode::InternalError, None, None);
                 }
 
                 QueueMsg::WorkerErrorCancelled { path, queue_id } => {
                     error!("Worker cancelled: {path}: {queue_id}");
+                    send::queue_status(&IpcQueueOpCode::InternalError, None, None);
                 }
 
             }

--- a/src-tauri/src/img_cache/queue.rs
+++ b/src-tauri/src/img_cache/queue.rs
@@ -1,33 +1,63 @@
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use std::{
-    // io::ErrorKind,
-    collections::{HashMap, HashSet}, path::PathBuf, sync::{
+    collections::HashSet,
+    path::PathBuf,
+    sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
-    }
+    },
 };
-use tokio::{
-    // fs,
-    sync::mpsc,
-    // task,
-};
+use tokio::sync::mpsc;
 
-use crate::img_cache::queue_worker::QueueWorker;
-// use crate::{img_cache::{cache, img, queue_worker::{handle_create_thumbnail_result, QueueWorker}}, ipc::send};
-// use crate::get_db;
+use crate::{get_db, img_cache::queue_worker::QueueWorker, ipc::send};
 
 #[derive(Debug, Clone)]
 pub struct QueueItem {
     pub full_path: PathBuf,
     pub path_hash: String,
     pub file_hash: String,
+    pub queue_id: String,
+}
+
+impl QueueItem {
+    pub fn new(full_path: PathBuf, path_hash: String, file_hash: String) -> Self {
+        Self {
+            queue_id: Self::id_from_hashes(&file_hash, &path_hash),
+            full_path,
+            path_hash,
+            file_hash,
+        }
+    }
+    fn id_from_hashes(file_hash: &String, path_hash: &String) -> String {
+        format!("{}{}", &file_hash, &path_hash)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub enum QueueMsg {
-    ImageAdded { file_hash: String },
-    ImageFailed { file_hash: String },
-    WorkerComplete { file_hash: String },
+    ImageAdded {
+        queue_id: String,
+    },
+    ImageCompleted {
+        path_hash: String,
+        filename_hash: String,
+        path: String,
+        queue_id: String,
+    },
+    ImageFailed {
+        file_hash: String,
+        path: String,
+        error: String,
+        queue_id: String,
+    },
+    WorkerErrorJoin {
+        path: String,
+        queue_id: String,
+    },
+    WorkerErrorCancelled {
+        path: String,
+        queue_id: String,
+    },
 }
 
 #[derive(Debug)]
@@ -38,25 +68,33 @@ pub struct Queue {
 }
 
 impl Queue {
-    pub fn new() -> (Self, mpsc::UnboundedReceiver<QueueItem>, mpsc::UnboundedReceiver<QueueMsg>) {
+    pub fn new() -> (
+        Self,
+        mpsc::UnboundedReceiver<QueueItem>,
+        mpsc::UnboundedReceiver<QueueMsg>,
+    ) {
         let (item_sender, item_receiver) = mpsc::unbounded_channel();
         let (event_sender, event_receiver) = mpsc::unbounded_channel();
         let size = Arc::new(AtomicUsize::new(0));
 
-        let queue = Queue { item_sender, size, event_sender };
+        let queue = Queue {
+            item_sender,
+            size,
+            event_sender,
+        };
 
         (queue, item_receiver, event_receiver)
     }
 
     // enqueue an item and increment the queue size
     pub async fn enqueue(&self, item: QueueItem) -> Result<(), String> {
-        let event_payload = item_hash(&item);
+        let queue_id = item.queue_id.clone();
         match self.item_sender.send(item) {
             Ok(_) => {
                 self.size.fetch_add(1, Ordering::SeqCst);
-                let _ = self.event_sender.send(
-                    QueueMsg::ImageAdded{ file_hash: event_payload }
-                );
+                let _ = self.event_sender.send(QueueMsg::ImageAdded {
+                    queue_id
+                });
                 Ok(())
             }
             Err(_) => Err("Failed to enqueue item".to_string()),
@@ -69,19 +107,27 @@ impl Queue {
 }
 
 struct QueueSize {
-    size: Arc<AtomicUsize>
+    size: Arc<AtomicUsize>,
 }
 impl QueueSize {
-    fn get(&self) -> usize { self.size.load(Ordering::SeqCst) }
-    fn inc(&self) -> usize { self.size.fetch_add(1, Ordering::SeqCst) }
-    fn dec(&self) -> usize { self.size.fetch_sub(1, Ordering::SeqCst).saturating_sub(1) }
+    fn get(&self) -> usize {
+        self.size.load(Ordering::SeqCst)
+    }
+    // fn inc(&self) -> usize {
+    //     self.size.fetch_add(1, Ordering::SeqCst)
+    // }
+    fn dec(&self) -> usize {
+        self.size.fetch_sub(1, Ordering::SeqCst).saturating_sub(1)
+    }
 }
 
 // initializer
 pub async fn setup_queue() -> Queue {
     let (queue, mut main_receiver, mut main_event_receiver) = Queue::new();
     let size_ref = queue.size.clone();
-    let queue_size = QueueSize { size: queue.size.clone() };
+    let queue_size = QueueSize {
+        size: queue.size.clone(),
+    };
 
     let core_count = std::thread::available_parallelism()
         .map(|p| p.get())
@@ -95,63 +141,115 @@ pub async fn setup_queue() -> Queue {
     info!("Detected {core_count} CPU cores, spawning {worker_count} thumbnail workers");
 
     let mut worker_senders: Vec<mpsc::UnboundedSender<QueueItem>> =
-    Vec::with_capacity(worker_count);
+        Vec::with_capacity(worker_count);
     for i in 0..worker_count {
         let main_event_sender = queue.event_sender.clone();
         let (worker_sender, worker_receiver) = mpsc::unbounded_channel();
         worker_senders.push(worker_sender);
 
-        let size_ref_clone = size_ref.clone();
         tokio::spawn(async move {
             debug!("Starting worker {i}");
-            QueueWorker::start(worker_receiver, main_event_sender, size_ref_clone).await;
+            QueueWorker::start(worker_receiver, main_event_sender).await;
         });
     }
 
     tokio::spawn(async move {
         info!("Starting queue dispatcher.");
 
-        let mut processing: HashMap<String,QueueItem> = HashMap::new();
+        let mut processing: HashSet<String> = HashSet::new();
         let mut blacklist: HashSet<String> = HashSet::new();
 
         let mut next_worker_idx = 0;
         while let Some(msg) = main_event_receiver.recv().await {
 
             match msg {
-                QueueMsg::ImageAdded { file_hash: _ } => {
+
+                QueueMsg::ImageAdded { queue_id } => {
                     if let Some(img) = main_receiver.recv().await {
-                        if blacklist.contains(&item_hash(&img)) {
-                            // TODO: message frontend
+                        if blacklist.contains(&queue_id) {
+                            send::info_window_msg(
+                                &format!(
+                                    "Found and skipped thumbnail for previously failed image: {}",
+                                    &img.full_path.to_string_lossy()
+                                ));
                             continue;
                         }
 
-                        if processing.contains_key(&item_hash(&img)) {
-                            debug!("Ignoring enqueue, already in queue: {}", &img.full_path.to_string_lossy());
+                        if processing.contains(&queue_id) {
+                            warn!(
+                                "Ignoring enqueue, already in queue: {}",
+                                &img.full_path.to_string_lossy()
+                            );
 
-                            debug!("Decrementing queue from: {:?}", &size_ref);
                             queue_size.dec();
-                            debug!("New queue size: {:?}", &size_ref);
                             continue;
                         }
+
+                        processing.insert(queue_id);
 
                         let worker_sender = &worker_senders[next_worker_idx];
                         worker_sender.send(img)
                             .unwrap_or_else(|e| error!("Failed to dispatch item to worker: {e}"));
                         next_worker_idx = (next_worker_idx + 1) % worker_senders.len();
                     }
-                }
-
-                QueueMsg::WorkerComplete { file_hash } => {
-                    // TODO: message frontend
-                    processing.remove(&file_hash);
-                    queue_size.dec();
-                }
-
-                QueueMsg::ImageFailed { file_hash } => {
-                    if !blacklist.contains(&file_hash) {
-                        blacklist.insert(file_hash);
+                    else {
+                        queue_size.dec();
+                        error!("QueueMsg -> ImageAdded: main_receiver.recv() found None, expected Some.");
                     }
                 }
+
+                QueueMsg::ImageCompleted {
+                    path_hash,
+                    filename_hash,
+                    path,
+                    queue_id,
+                } => {
+                    if processing.contains(&queue_id) {
+                        processing.remove(&queue_id);
+                        queue_size.dec();
+
+                        if let Err(db_error) = get_db().insert_hash(&path_hash, &filename_hash, &path) {
+                            let error_message = format!(
+                                "Failed to record journal entry for {}, hash: {} / {}.\nError: {db_error}",
+                                path, path_hash, filename_hash
+                            );
+                            send::info_window_msg(&error_message);
+                            error!("{}", error_message);
+                            blacklist.insert(queue_id);
+                        }
+                        else {
+                            // TODO: notify frontend to fetch image
+                            debug!("Notify frontend.");
+                        }
+
+                        frontend_queue_progress(queue_size.get());
+                    }
+                    else {
+                        error!("QueueMsg -> ImageCompleted: No matching record in processing for id: {queue_id}");
+                    }
+                }
+
+                QueueMsg::ImageFailed { file_hash, path, error, queue_id } => {
+                    warn!("Failed to generate thumbnail for: {path}");
+                    send::info_window_msg(&format!("Failed to generate thumbnail for {path}, error: {error}"));
+
+                    if processing.remove(&queue_id) {
+                        queue_size.dec();
+                    }
+
+                    if !blacklist.insert(queue_id) {
+                        error!("Failed to add to blacklist: {}", &file_hash);
+                    }
+                }
+
+                QueueMsg::WorkerErrorJoin { path, queue_id } => {
+                    error!("Worker join error: {path}: {queue_id}");
+                }
+
+                QueueMsg::WorkerErrorCancelled { path, queue_id } => {
+                    error!("Worker cancelled: {path}: {queue_id}");
+                }
+
             }
         }
 
@@ -161,6 +259,15 @@ pub async fn setup_queue() -> Queue {
     queue
 }
 
-fn item_hash(item: &QueueItem) -> String {
-    format!("{}{}", &item.file_hash, &item.path_hash)
+//
+// helpers/utility
+//
+
+fn frontend_queue_progress(queue_size: usize) {
+    if queue_size == 0 {
+        send::info_window_msg("Thumbnails generated.");
+    }
+    else if queue_size % 10 == 0 || queue_size < 10 {
+        send::info_window_msg(&format!("{queue_size:?} thumbnails in queue."));
+    }
 }

--- a/src-tauri/src/img_cache/queue.rs
+++ b/src-tauri/src/img_cache/queue.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use tokio::sync::mpsc;
 
-use crate::{get_db, img_cache::queue_worker::QueueWorker, ipc::send};
+use crate::{get_db, img_cache::queue_worker::QueueWorker, ipc::{send, types::IpcQueueOpCode}};
 
 #[derive(Debug, Clone)]
 pub struct QueueItem {
@@ -219,8 +219,11 @@ pub async fn setup_queue() -> Queue {
                             blacklist.insert(queue_id);
                         }
                         else {
-                            // TODO: notify frontend to fetch image
-                            debug!("Notify frontend.");
+                            send::queue_status(
+                                &IpcQueueOpCode::ImageComplete,
+                                Some(&filename_hash),
+                                Some(&path_hash)
+                            );
                         }
 
                         frontend_queue_progress(queue_size.get());
@@ -271,4 +274,8 @@ fn frontend_queue_progress(queue_size: usize) {
     else if queue_size % 10 == 0 || queue_size < 10 {
         send::info_window_msg(&format!("{queue_size:?} thumbnails in queue."));
     }
+}
+
+fn frontend_can_fetch(id: String){
+    // TODO: sends a message that the frontend can now fetch this image.
 }

--- a/src-tauri/src/img_cache/queue_worker.rs
+++ b/src-tauri/src/img_cache/queue_worker.rs
@@ -1,0 +1,121 @@
+use log::{debug, error, info};
+use std::{
+    io::ErrorKind,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    }
+};
+use tokio::{
+    fs,
+    sync::mpsc,
+    task::{self, JoinError},
+};
+
+use crate::img_cache::{cache, img, queue::{QueueItem, QueueMsg}};
+use crate::ipc::send;
+use crate::get_db;
+
+pub struct QueueWorker;
+
+impl QueueWorker {
+    pub async fn start(
+        mut receiver: mpsc::UnboundedReceiver<QueueItem>,
+        event_sender: mpsc::UnboundedSender<QueueMsg>,
+        size: Arc<AtomicUsize>,
+    ) {
+        // check base cache directory
+        let cache_path = match cache::get_cache_path_async().await {
+            Ok(path) => path,
+            Err(e) => {
+                error!("QueueWorker failed to get or create cache path: {e}");
+                return;
+            }
+        };
+
+        while let Some(item) = receiver.recv().await {
+            debug!("Generate thumbnail: {}", item.full_path.to_string_lossy());
+
+            let mut thumb_path = cache_path.clone();
+            thumb_path.push(&item.path_hash);
+
+            // ensure the specific item's hash directory exists
+            match fs::create_dir_all(&thumb_path).await {
+                Ok(_) => {},
+                Err(e) if e.kind() == ErrorKind::AlreadyExists => {},
+                Err(e) => {
+                    // TODO: granular error handling
+                    error!("Failed to create item-specific directory {thumb_path:?}: {e}");
+                    size.fetch_sub(1, Ordering::SeqCst);
+                    continue;
+                }
+            }
+
+            thumb_path.push(&item.file_hash);
+            thumb_path.set_extension("webp");
+
+            let org_path = item.full_path.clone();
+            let result = task::spawn_blocking(move || {
+                img::create_thumbnail(org_path.as_path(), &thumb_path)
+            })
+            .await; // awaits JoinHandle from spawn_blocking
+
+
+            match result {
+                Ok(Ok(())) => {
+                    debug!("Thumbnail generated successfully for {}", item.full_path.to_string_lossy());
+
+                    if let Err(e) = get_db().insert_hash(
+                        &item.path_hash,
+                        &item.file_hash,
+                        &item.full_path.to_string_lossy()
+                    ) {
+                        error!("Failed to insert hash for {}, {}", item.full_path.to_string_lossy(), e);
+                    }
+                }
+                Ok(Err(e)) => {
+                    let failed_img_path = item.full_path.to_string_lossy();
+                    match e {
+                        image::ImageError::Unsupported(unsupported_error) => {
+                            error!("image failed to generate thumbnail for file: {failed_img_path}");
+                            error!("image error: {unsupported_error}");
+                            send::info_window_msg(&format!("Failed to create thumbnail for: {failed_img_path}"));
+                            send::info_window_msg(&format!("Reason: {unsupported_error}"));
+                        }
+                        _ => {
+                            error!("Error generating thumbnail for {failed_img_path}: {e}");
+                        }
+                    }
+                }
+                Err(join_error) => {
+                    error!("Spawn blocking task for {} failed: {:?}", item.full_path.to_string_lossy(), join_error);
+
+                    if join_error.is_panic() {
+                        error!("try_into_panic(): true");
+                    }
+                    if join_error.is_cancelled() {
+                        error!("is_cancelled(): true");
+                    }
+                }
+            }
+
+            let remaining = size.fetch_sub(1, Ordering::SeqCst).saturating_sub(1);
+            if remaining % 10 == 0 || remaining < 10 {
+                if remaining > 0 {
+                    send::info_window_msg(&format!("{remaining:?} thumbnails in queue."));
+                }
+                else {
+                    if let Some(parent) = item.full_path.parent() {
+                        // TODO: readability TODO_QUEUE_STATUS_PARAMS
+                        // update to use enum/type params
+                        // sending: redraw=true, queue_empty=true
+                        send::queue_status(parent, &true, &true);
+                    }
+                    send::info_window_msg("Thumbnails generated.");
+                }
+                info!("{remaining:?} images remaining in queue.");
+            }
+        }
+        info!("Worker shutting down");
+    }
+}

--- a/src-tauri/src/ipc/send.rs
+++ b/src-tauri/src/ipc/send.rs
@@ -1,8 +1,6 @@
-use std::path::Path;
-
 use log::debug;
 use tauri::Emitter;
-use crate::{get_app_handle, ipc::types::{IpcMsgInfoWindow, IpcQueueState}};
+use crate::{get_app_handle, ipc::types::{IpcMsgInfoWindow, IpcQueueOpCode, IpcQueueState}};
 
 pub fn info_window_msg(message: &str) -> bool {
     let res = get_app_handle().emit_to("global-handler", "msg-info-window", IpcMsgInfoWindow { message });
@@ -18,10 +16,14 @@ pub fn info_window_msg(message: &str) -> bool {
         }
     }
 }
-pub fn queue_status(path: &Path, redraw: &bool, queue_empty: &bool) -> bool {
-    let path = path.to_str().unwrap();
-
-    let res = get_app_handle().emit_to("global-handler", "msg-queue-status", IpcQueueState { path, redraw, queue_empty });
+pub fn queue_status(opcode: &IpcQueueOpCode, img_hash: Option<&str>, path_hash: Option<&str>) -> bool {
+    let res = get_app_handle()
+        .emit_to("global-handler", "msg-queue-status", 
+            IpcQueueState {
+                opcode,
+                img_hash,
+                path_hash,
+            });
 
     match res {
         Ok(_) => {

--- a/src-tauri/src/ipc/types.rs
+++ b/src-tauri/src/ipc/types.rs
@@ -9,7 +9,15 @@ pub struct IpcMsgInfoWindow<'a> {
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IpcQueueState<'a> {
-    pub path: &'a str,
-    pub redraw: &'a bool,
-    pub queue_empty: &'a bool,
+    pub opcode: &'a IpcQueueOpCode,
+    pub img_hash: Option<&'a str>,
+    pub path_hash: Option<&'a str>,
+}
+
+#[derive(Clone, Serialize)]
+pub enum IpcQueueOpCode {
+    ImageComplete,
+    ImageFailed,
+    InternalError,
+    ImageQueueEmpty
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ fn main() {
         .filter_module("vimages_lib::endpoints::fs", log::LevelFilter::Info)
         .filter_module("vimages_lib::img_cache::cache", log::LevelFilter::Info)
         .filter_module("vimages_lib::img_cache::queue", log::LevelFilter::Info)
+        .filter_module("vimages_lib::ipc::send", log::LevelFilter::Info)
         .init();
     vimages_lib::run()
 }

--- a/src/context/app/app.context.actions.ts
+++ b/src/context/app/app.context.actions.ts
@@ -14,33 +14,7 @@ import { timestamp } from '@context/helpers';
 // State
 //
 
-export const IPC_PendingRemoves = new Set<string>();
-
 export function getDirectory(store: StoreApi<IAppState>, relPath: string){
-	console.log("getDirectory: " + relPath);
-	invoke(RustApiAction.ResolveRelPath, {
-		path: store.getState().currentDir,
-		relPath
-	})
-		.then(responseRelPath => {
-			const abspath = responseRelPath as string;
-			if(IPC_PendingRemoves.has(abspath)){
-				raiseError(store, "Directory is being processed, please wait for thumbnail generation queue to complete.");
-				return;
-			}
-
-			IPC_PendingRemoves.add(abspath);
-
-			getDirectorySkipLock(store, relPath);
-		});
-}
-
-/**
- * Bypasses lock for React strict mode compatibility.
- * Do not use outside of app init or IPC callbacks where duplication is less of a concern.
- * Use `getDirectory()` instead.
- * */
-export function getDirectorySkipLock(store: StoreApi<IAppState>, relPath: string){
 	invoke(RustApiAction.GetDir, { 
 		path: store.getState().currentDir, 
 		relPath 

--- a/src/context/app/app.context.actions.ts
+++ b/src/context/app/app.context.actions.ts
@@ -46,6 +46,29 @@ export function updateImageThumbnailState(store: StoreApi<IAppState>, imgHash: s
 	}
 }
 
+export function updateImageThumbnailStateBatch(store: StoreApi<IAppState>, buffer: Set<string> | null) {
+	if(buffer === null) return;
+
+	let images = store.getState().images;
+	let hits = 0;
+	let size = buffer.size;
+	let idxs = new Set<number>();
+
+	for(let i = 0; i < images.length; i++){
+		if(buffer.has(images[i].img_hash)){
+			idxs.add(i);
+			hits += 1;
+			if(hits === size) break;
+		}
+	}
+
+	if(hits > 0) {
+		let update = [... images];
+		idxs.forEach(x => update[x].has_thumbnail = true);
+		store.getState().setImages(update);
+	}
+}
+
 export function getDirectoryHistory(store: StoreApi<IAppState>): string | undefined {
 	const dir = store.getState().currentDir;
 	return store.getState().dirHistory.get(dir);

--- a/src/context/app/app.context.actions.ts
+++ b/src/context/app/app.context.actions.ts
@@ -62,6 +62,16 @@ export function getDirectorySkipLock(store: StoreApi<IAppState>, relPath: string
 		});
 }
 
+export function updateImageThumbnailState(store: StoreApi<IAppState>, imgHash: string, hasThumbnail: boolean) {
+	let images = store.getState().images;
+	let idx = images.findIndex((a) => a.img_hash === imgHash);
+	if(idx >= 0 && idx < images.length) {
+		let update = [... images];
+		update[idx].has_thumbnail = hasThumbnail;
+		store.getState().setImages(update);
+	}
+}
+
 export function getDirectoryHistory(store: StoreApi<IAppState>): string | undefined {
 	const dir = store.getState().currentDir;
 	return store.getState().dirHistory.get(dir);

--- a/src/context/app/app.context.tsx
+++ b/src/context/app/app.context.tsx
@@ -5,7 +5,7 @@ import { getVersion } from "@tauri-apps/api/app";
 import { createContext, useEffect, useContext } from "react";
 
 import { useAppState } from "./app.context.store";
-import { addInfoMessage, getDirectorySkipLock, raiseError, setWorkspace } from "./app.context.actions";
+import { addInfoMessage, getDirectory, raiseError, setWorkspace } from "./app.context.actions";
 
 import { NormalModeHandler } from "@app/handler/mode.normal";
 import { CommandModeHandler } from "@app/handler/mode.command";
@@ -86,9 +86,8 @@ export const AppContextProvider = ({ children }: { children: React.ReactNode }) 
 					addInfoMessage(useAppState, `Found config for ${confVer}, expected ${expVer}.`);
 				}
 
-				// NOTE: lock doesn't clean up properly in react strict mode
-				// the callback is cleared before it can remove the path from the lock
-				getDirectorySkipLock(useAppState, res.last_path);
+				// load last directory
+				getDirectory(useAppState, res.last_path);
 
 				// setup keybindings
 				let keyMap = new Map<string, Command>();

--- a/src/context/app/app.event.listeners.ts
+++ b/src/context/app/app.event.listeners.ts
@@ -2,45 +2,26 @@ import { StoreApi } from "zustand";
 import { Event as TauriEvent} from "@tauri-apps/api/event";
 
 import { IAppState } from "@app/app.context.store";
-import { addInfoMessage, getDirectorySkipLock, IPC_PendingRemoves } from "@app/app.context.actions";
+import { addInfoMessage, updateImageThumbnailState } from "@app/app.context.actions";
 
-import { IPC_MsgInfoWindow, IPC_QueueStatus } from "./app.event.types";
+import { IPC_MsgInfoWindow, IPC_QueueOpCode, IPC_QueueStatus } from "./app.event.types";
 
 export const eventHandleMsgInfoWindow = (event: TauriEvent<IPC_MsgInfoWindow>, useAppState: StoreApi<IAppState>) => {
 	addInfoMessage(useAppState, event.payload.message);
 };
 
 export const eventHandleQueueState = (event: TauriEvent<IPC_QueueStatus>, store: StoreApi<IAppState>) => {
-	// TODO: REFACTOR: REFACTOR_IMAGE_PIPELINE 
-	// currently only receives redraw messages when lock should be released.
-	//  - implement proper opcodes later.
-	//  - backend queue pipeline needs to be improved to discern individual directories.
+	// TODO: handle other messages
 
-	if(event.payload.queueEmpty) {
-		console.log("Queue is empty, clear all locks.");
-		IPC_PendingRemoves.clear();
+	let msg = event.payload as IPC_QueueStatus;
 
-		// Redraw
-		if(event.payload.path === store.getState().currentDir)
-			getDirectorySkipLock(store, ".");
-		return;
+	if(msg.opcode === IPC_QueueOpCode.ImageComplete) {
+		if(msg.imgHash === null) {
+			console.error("Incomplete message from backend. OpCode=ImageComplete, but imgHash was null.");
+			return;
+		}
+		updateImageThumbnailState(store, msg.imgHash, true);
 	}
 
-	if(!IPC_PendingRemoves.has(event.payload.path)){
-		console.warn("eventHandleQueueState was called, but no lock exists for path: " + event.payload.path);
-		return;
-	}
-
-	IPC_PendingRemoves.delete(event.payload.path);
-
-	if(event.payload.path !== store.getState().currentDir){
-		console.log("Queue message redraw call ignored, path not currentDir.");
-		console.log("path=" + event.payload.path + " || currentDir=" + store.getState().currentDir);
-		return;
-	}
-
-	if(event.payload.redraw) {
-		getDirectorySkipLock(store, ".");
-		return;
-	}
+	return;
 }

--- a/src/context/app/app.event.listeners.ts
+++ b/src/context/app/app.event.listeners.ts
@@ -2,13 +2,63 @@ import { StoreApi } from "zustand";
 import { Event as TauriEvent} from "@tauri-apps/api/event";
 
 import { IAppState } from "@app/app.context.store";
-import { addInfoMessage, updateImageThumbnailState } from "@app/app.context.actions";
+import { addInfoMessage, updateImageThumbnailState, updateImageThumbnailStateBatch } from "@app/app.context.actions";
 
 import { IPC_MsgInfoWindow, IPC_QueueOpCode, IPC_QueueStatus } from "./app.event.types";
 
 export const eventHandleMsgInfoWindow = (event: TauriEvent<IPC_MsgInfoWindow>, useAppState: StoreApi<IAppState>) => {
 	addInfoMessage(useAppState, event.payload.message);
 };
+
+// NOTE: image pipeline can output images faster than react can complete state updates, causing UI lag.
+// batching updates to images to partially mitigate this.
+// TODO: review DS and explore other options for potential improvements
+
+// double buffer thumbnail updates
+const flushTimeout = 200; // [ms] to wait without pushes to buffer before clearing
+const thumbBufFlushThreshold = 100; // capacity of each buffer
+
+let thumbTimerFlush: number | null = null;
+
+let thumbBuf: Set<string>[] = [];
+thumbBuf.push(new Set<string>());
+thumbBuf.push(new Set<string>());
+let thumbBufLength: number[] = [0,0];
+
+let thumbActiveBuf: number = 0;
+let thumbInactiveBuf: number = 1;
+
+function bufferThumbnailUpdate(imgHash: string): Set<string> | null {
+	thumbBuf[thumbActiveBuf].add(imgHash);
+	thumbBufLength[thumbActiveBuf] += 1;
+
+	if(thumbBufLength[thumbActiveBuf] >= thumbBufFlushThreshold) {
+		[thumbActiveBuf, thumbInactiveBuf] = [thumbInactiveBuf, thumbActiveBuf];
+		let flush = new Set<string>(thumbBuf[thumbInactiveBuf]);	
+		
+		thumbBuf[thumbInactiveBuf].clear();
+		thumbBufLength[thumbInactiveBuf] = 0;
+
+		return flush;
+	}
+	return null;
+}
+
+function bufferFlush(): Set<string> | null {
+	let flush;
+	if(thumbBufLength[thumbActiveBuf] > 0) {
+		flush = new Set<string>(thumbBuf[thumbActiveBuf]);	
+	}
+	else {
+		flush = null;
+	}
+	thumbTimerFlush = null;
+	thumbBuf[0].clear();
+	thumbBuf[1].clear();
+	thumbBufLength[0] = 0;
+	thumbBufLength[1] = 0;
+	return flush;	
+}
 
 export const eventHandleQueueState = (event: TauriEvent<IPC_QueueStatus>, store: StoreApi<IAppState>) => {
 	// TODO: handle other messages
@@ -20,7 +70,23 @@ export const eventHandleQueueState = (event: TauriEvent<IPC_QueueStatus>, store:
 			console.error("Incomplete message from backend. OpCode=ImageComplete, but imgHash was null.");
 			return;
 		}
-		updateImageThumbnailState(store, msg.imgHash, true);
+
+		let buffer = bufferThumbnailUpdate(msg.imgHash);
+
+		if(buffer !== null) {
+			updateImageThumbnailStateBatch(store, buffer);
+		}
+
+		if (thumbTimerFlush !== null) {
+			clearTimeout(thumbTimerFlush);
+		}
+
+		if(thumbBufLength[0] > 0 || thumbBufLength[1] > 0) {
+			thumbTimerFlush = setTimeout(() => {
+				const buffer = bufferFlush();
+				updateImageThumbnailStateBatch(store, buffer);
+			}, flushTimeout);
+		}
 	}
 
 	return;

--- a/src/context/app/app.event.types.ts
+++ b/src/context/app/app.event.types.ts
@@ -2,7 +2,13 @@ export type IPC_MsgInfoWindow = {
 	message: string,
 };
 export type IPC_QueueStatus = {
-	path: string,
-	redraw: boolean,
-	queueEmpty: boolean,
+	opcode: IPC_QueueOpCode,
+	imgHash: string | null,
+	pathHash: string | null,
+};
+export enum IPC_QueueOpCode {
+	ImageComplete = "ImageComplete",
+	ImageFailed = "ImageFailed",
+	InternalError = "InternalError",
+	ImageQueueEmpty = "ImageQueueEmpty",
 };

--- a/src/context/app/handler/mode.command.ts
+++ b/src/context/app/handler/mode.command.ts
@@ -2,7 +2,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 
 import { useAppState } from "@app/app.context.store";
-import { addInfoMessage, addInfoMessageArray, getDirectory, IPC_PendingRemoves, raiseError, saveConfig, setWorkspace } from "@app/app.context.actions"
+import { addInfoMessage, addInfoMessageArray, getDirectory, raiseError, saveConfig, setWorkspace } from "@app/app.context.actions"
 
 import { Command } from "@key/key.command";
 import { Modal } from "@key/key.types";
@@ -198,8 +198,9 @@ export function CommandModeHandler(resultCommand: resultModeCommand){
 					});
 				break;
 			case ConsoleCmd.GetQueueDirs:
-				addInfoMessage(useAppState, "Locked directories:");
-				addInfoMessageArray(useAppState, Array.from(IPC_PendingRemoves));
+				addInfoMessage(useAppState, "Locked directories: feature disabled.");
+				// TODO: update for new pipeline
+				// addInfoMessageArray(useAppState, Array.from(IPC_PendingRemoves));
 				break;
 
 			//


### PR DESCRIPTION
Refactor the thumbnail pipeline to a dual channel actor system to improve thumbnail loading responsiveness and robustness.

**changelog:**

- Improved SOC in thumbnail queue with clearer areas of responsibilities for dispatcher and workers.
- Implement duplication prevention pre-dispatch in queue.
- Implement blacklisting of failed items in queue which persists for the runtime of the application.
- Implement double buffer in front-end IPC pipeline to batch thumbnail updates to react state.
- Remove directory locking from front-end, as de-duplication is now handled by queue.
- Remove IPC messages being emitted from the fs-endpoint.
- Disable `:get queue` command as it was used to output currently locked directories.